### PR TITLE
Fix New Line Issue in `echoflow rules --add` Command

### DIFF
--- a/echodataflow/echodataflow_cli.py
+++ b/echodataflow/echodataflow_cli.py
@@ -169,7 +169,9 @@ def add_rules_from_set(rule_set: set):
         if ':' not in rule:
             print("Sanity check failed. Please make sure all rules follow the convention : One rule per line. Format -> parent_flow:child_flow")
             raise ValueError("Error adding rules. Sanity Check failed.") 
-                   
+        if len(rule.split(':')) != 2:
+            print("Sanity check failed. Please make sure all rules follow the convention : One rule per line. Format -> parent_flow:child_flow")
+            raise ValueError("Error adding rules. Sanity Check failed.")
     with open(rules_path, 'w') as ruleset:        
         for rule in rule_set:
             ruleset.write(rule)    

--- a/echodataflow/echodataflow_cli.py
+++ b/echodataflow/echodataflow_cli.py
@@ -135,6 +135,9 @@ def add_new_rule(new_rule) -> None:
     Returns:
         None
     """
+    if len(new_rule.split(':')) != 2:
+        print("Sanity check failed. Please make sure all rules follow the convention : One rule per line. Format -> parent_flow:child_flow")
+        raise ValueError("Error adding rules. Sanity Check failed.")
     rules_path = fetch_ruleset()
     """Append a new rule to the existing rules file."""
     with open(rules_path, 'a') as file:

--- a/echodataflow/echodataflow_cli.py
+++ b/echodataflow/echodataflow_cli.py
@@ -138,7 +138,7 @@ def add_new_rule(new_rule) -> None:
     rules_path = fetch_ruleset()
     """Append a new rule to the existing rules file."""
     with open(rules_path, 'a') as file:
-        file.write(new_rule)
+        file.write(new_rule+"\n")
     print("New rule added successfully.")
     
 def add_rules_from_set(rule_set: set):


### PR DESCRIPTION
This PR addresses the issue reported in #66 where the `echoflow rules --add` command incorrectly appended new rules without inserting new lines, leading to parsing and application errors.

What's New?
1. New line while adding a rule using `--add` flag
2. Clean flag: `echodataflow rules --clean` will now clean and validate the rules.
3. Validation for multiple rules defined on a single line

Closes #66 