### PR TITLE
Validation check for regex in `group_name` attribute

### DIFF
--- a/echodataflow/models/datastore.py
+++ b/echodataflow/models/datastore.py
@@ -17,10 +17,11 @@ Email: sbutala@uw.edu
 Date: August 22, 2023
 """
 from enum import Enum
+import re
 from typing import Any, Dict, List, Optional
 
 import jinja2
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator, validator
 
 
 class StorageType(Enum):
@@ -119,10 +120,13 @@ class Args(BaseModel):
             return template.render(self.parameters)
         return self.urlpath
     
-    @validator('group_name', pre=True, always=True)
-    def convert_number_to_string(cls, v):
+    @field_validator('group_name', mode='before', check_fields=True)
+    def disallow_regex_chars(cls, v):
         if isinstance(v, int):
-            return str(v)
+            v = str(v)
+        regex_special_chars = r'[{}()|\[\]\\]'
+        if re.search(regex_special_chars, v):
+            raise ValueError("Field must not contain regex special characters")
         return v
 
 


### PR DESCRIPTION
We identified an issue where passing a regular expression as `group_name`, which is intended to be a simple string, results in unexpected behavior. This attribute is crucial as it maps to `transect_num` and is used by `echopype`. Although the test workflow did not utilize transect-focused stages like `combine_echodata`, errors were observed during the `compute_Sv` stage that was followed by `open_raw`. This PR aims to address this by implementing a validation check to ensure `group_name` contains only valid characters.

