### PR TITLE
Upgrades to Deploy Automated Ship Pipeline: New Flows, Improved Logging, and Enhanced Cleanup

### DIFF
--- a/echodataflow/aspects/echodataflow_aspect.py
+++ b/echodataflow/aspects/echodataflow_aspect.py
@@ -85,29 +85,6 @@ def echodataflow(processing_stage: str = "DEFAULT", type: str = "TASK"):
                 after_function_call(gea, *args, **kwargs)
                 return result
             except Exception as e:
-                if type == "TASK":
-                    return {"error": True, "error_desc": e}
-                else:
-                    try:
-                        client = get_client()
-                        if client:
-                            ev = client.get_events("echodataflow")
-                        if isinstance(ev, Coroutine):
-                            ev = asyncio.run(ev)
-                        for log in ev:
-                            if gea:
-                                gea.log(
-                                    msg=log[1]["msg"],
-                                    extra={
-                                        "mod_name": log[1]["mod_name"],
-                                        "func_name": log[1]["func_name"],
-                                    },
-                                    level=logging.DEBUG,
-                                )
-                            else:
-                                print(log)
-                    except Exception as ex:
-                        pass
                 raise e
 
         return wrapper

--- a/echodataflow/config/ship-pipeline/datastore.yaml
+++ b/echodataflow/config/ship-pipeline/datastore.yaml
@@ -1,0 +1,14 @@
+name: Bell_M._Shimada-SH2208-EK80
+sonar_model: EK60 
+raw_regex: (.*)-?D(?P<date>\w{1,8})-T(?P<time>\w{1,6}) 
+args: 
+  urlpath: s3://ncei-wcsd-archive/data/raw/Bell_M._Shimada/SH1707/EK60/{{file_name}}.raw
+  parameters:
+    file_name: Hake-D20220720-T234313
+  storage_options:
+    anon: true
+  json_export: true 
+output: 
+  urlpath: /home/exouser/Echodataflow/EK60/echodataflow-output
+  retention: true
+  overwrite: true

--- a/echodataflow/config/ship-pipeline/hake_prediction_datastore.yaml
+++ b/echodataflow/config/ship-pipeline/hake_prediction_datastore.yaml
@@ -1,0 +1,19 @@
+name: Bell_M._Shimada-SH1707-EK60
+sonar_model: EK60
+raw_regex: (.*)-?D(?P<date>\w{1,8})-T(?P<time>\w{1,6}) 
+args: 
+  storepath: /home/exouser/Echodataflow/EK60/stores/MVBSStore/zarr_files/{{file_name}}.zarr
+  parameters:
+    file_name: Bell_M._Shimada-SH2208-EK80
+  storage_options:
+    anon: true
+  window_size: 500
+  time_travel_hours: 2
+  time_travel_mins: 0
+  rolling_size: 500
+  json_export: true 
+output: 
+  urlpath: /home/exouser/Echodataflow/EK60/echodataflow-output/ml
+  retention: true
+  overwrite: true
+  

--- a/echodataflow/config/ship-pipeline/hake_prediction_pipeline.yaml
+++ b/echodataflow/config/ship-pipeline/hake_prediction_pipeline.yaml
@@ -1,0 +1,28 @@
+active_recipe: target_strength 
+use_local_dask: true
+pipeline:
+- recipe_name: target_strength
+  stages:
+  - name: slice_store
+    module: echodataflow.stages.subflows.slice_store
+    options:      
+      group: False
+  - name: echodataflow_mask_prediction
+    module: echodataflow.stages.subflows.mask_prediction
+    options:
+      use_offline: true
+      group: False
+  - name: echodataflow_apply_mask
+    module: echodataflow.stages.subflows.apply_mask
+    options:
+      use_offline: true
+      group: False
+    dependson:
+      frequency_diff: mask
+  - name: echodataflow_compute_NASC
+    module: echodataflow.stages.subflows.compute_NASC
+    options:
+      use_offline: true
+      group: False
+    external_params:
+      range_bin: 1m

--- a/echodataflow/config/ship-pipeline/pipeline.yaml
+++ b/echodataflow/config/ship-pipeline/pipeline.yaml
@@ -1,0 +1,70 @@
+active_recipe: target_strength 
+# scheduler_address: tcp://127.0.0.1:3467
+use_local_dask: true
+n_workers: 3
+pipeline:
+- recipe_name: target_strength
+  stages:
+  - name: echodataflow_open_raw
+    module: echodataflow.stages.subflows.open_raw
+    options:
+      save_raw_file: true
+      use_raw_offline: true
+      use_offline: true
+      group: False
+  - name: echodataflow_compute_Sv
+    module: echodataflow.stages.subflows.compute_Sv
+    options:
+      use_offline: true
+      group: False
+  - name: echodataflow_add_depth
+    module: echodataflow.stages.subflows.add_depth
+    options:
+      use_offline: true
+      group: False  
+  - name: echodataflow_add_location
+    module: echodataflow.stages.subflows.add_location
+    options:
+      use_offline: true
+      group: False
+  - name: write_output
+    module: echodataflow.stages.subflows.write_output
+    options:
+      out_path: /home/exouser/Echodataflow/EK60/stores/SvStore
+      store_mode: True
+      group: False 
+  - name: slice_store
+    module: echodataflow.stages.subflows.slice_store
+    options:
+      out_path: /home/exouser/Echodataflow/EK60/stores/SvStore
+      store_mode: True
+      group: False
+    external_params:
+      ping_time_bin: 5S
+  - name: echodataflow_compute_MVBS
+    module: echodataflow.stages.subflows.compute_MVBS
+    options:
+      use_offline: true
+      group: False
+    external_params:
+      range_bin: 1m 
+      ping_time_bin: 5S
+      range_var: depth
+  - name: write_output
+    module: echodataflow.stages.subflows.write_output
+    options:
+      out_path: /home/exouser/Echodataflow/EK60/stores/MVBSStore
+      store_mode: True
+      group: False
+  # - name: echodataflow_mask_prediction
+  #   module: echodataflow.stages.subflows.mask_prediction
+  #   options:
+  #     use_offline: true
+  #     group: False
+  # - name: echodataflow_apply_mask
+  #   module: echodataflow.stages.subflows.apply_mask
+  #   options:
+  #     use_offline: true
+  #     group: False
+  #   dependson:
+  #     frequency_diff: mask

--- a/echodataflow/models/datastore.py
+++ b/echodataflow/models/datastore.py
@@ -106,7 +106,8 @@ class Args(BaseModel):
         raw_json_path (Optional[str]): Path for raw JSON data.
     """
 
-    urlpath: str
+    storepath: Optional[str] = None
+    urlpath: Optional[str] = None
     parameters: Parameters
     storage_options: Optional[StorageOptions] = None
     storage_options_dict: Optional[Dict[str, Any]] = {}
@@ -115,6 +116,11 @@ class Args(BaseModel):
     zarr_store: Optional[str] = None
     json_export: Optional[bool] = False
     raw_json_path: Optional[str] = None
+
+    window_size: Optional[int] = 1
+    time_travel_hours: Optional[int] = 0
+    time_travel_mins: Optional[int] = 0
+    rolling_size: Optional[int] = 1
 
     @property
     def rendered_path(self):
@@ -130,6 +136,21 @@ class Args(BaseModel):
             return template.render(self.parameters)
         return self.urlpath
 
+    @property
+    def store_path(self):
+        """
+        Rendered URL path from input parameters.
+
+        Returns:
+            str: Rendered URL path.
+        """
+        if self.parameters is not None:
+            env = jinja2.Environment()
+            template = env.from_string(self.storepath)
+            return template.render(self.parameters)
+        return self.storepath
+
+    
     @field_validator("group_name", mode="before", check_fields=True)
     def disallow_regex_chars(cls, v):
         if isinstance(v, int):

--- a/echodataflow/models/output_model.py
+++ b/echodataflow/models/output_model.py
@@ -60,6 +60,8 @@ class EchodataflowObject(BaseModel):
     group_name: str = "DefaultGroup"
     error: ErrorObject = ErrorObject()
     local_path: str = None
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
 
 
 class Group(BaseModel):

--- a/echodataflow/models/output_model.py
+++ b/echodataflow/models/output_model.py
@@ -27,6 +27,7 @@ class ErrorObject(BaseModel):
         error_desc (Optional[str]): Description of the error.
     """
 
+    error_type: str = "EXTERNAL"
     errorFlag: bool = False
     error_desc: str = None
 

--- a/echodataflow/models/pipeline.py
+++ b/echodataflow/models/pipeline.py
@@ -48,7 +48,7 @@ class Stage(BaseModel):
     name: str
     module: Optional[str] = None
     external_params: Optional[Dict[str, Any]] = None
-    options: Optional[Dict[str, Any]] = None
+    options: Optional[Dict[str, Any]] = {}
     prefect_config: Optional[Dict[str, Any]] = None
     dependson: Optional[Dict[str, Any]] = None
 

--- a/echodataflow/stages/echodataflow.py
+++ b/echodataflow/stages/echodataflow.py
@@ -40,12 +40,14 @@ from prefect_azure import AzureCosmosDbCredentials
 from pydantic import SecretStr
 
 from echodataflow.models.datastore import StorageType
-from echodataflow.models.echodataflow_config import (BaseConfig, EchodataflowConfig,
-                                             EchodataflowPrefectConfig)
-from echodataflow.utils.config_utils import get_storage_options, load_block
+from echodataflow.models.echodataflow_config import (
+    BaseConfig,
+    EchodataflowConfig,
+    EchodataflowPrefectConfig,
+)
+from echodataflow.utils.config_utils import load_block
 
 from echodataflow.stages.echodataflow_trigger import echodataflow_trigger
-from echodataflow.utils.file_utils import format_windows_path
 
 
 def check_internet_connection(host="8.8.8.8", port=53, timeout=5):
@@ -151,8 +153,7 @@ def load_profile(name: str):
 
     # Check if the specified profile exists
     if config.get("profiles").get(name) is None:
-        raise ValueError(
-            "No such profile exists. Please try creating profile with this name")
+        raise ValueError("No such profile exists. Please try creating profile with this name")
 
     # Set the specified profile as the active profile
     config["active"] = name
@@ -195,7 +196,7 @@ def echodataflow_start(
     logging_config: Union[Dict[str, Any], str, Path] = None,
     storage_options: Union[Dict[str, Any], Block] = None,
     options: Optional[Dict[str, Any]] = {},
-    json_data_path: Union[str, Path] = None
+    json_data_path: Union[str, Path] = None,
 ):
     """
     Start an Echodataflow pipeline execution.
@@ -232,13 +233,13 @@ def echodataflow_start(
     print("\nChecking Configuration")
     # Try loading the Prefect config block
     try:
-        echodataflow_config = load_block(
-            name="echodataflow-config", type=StorageType.ECHODATAFLOW)
+        echodataflow_config = load_block(name="echodataflow-config", type=StorageType.ECHODATAFLOW)
     except ValueError as e:
-        print("\nNo Prefect Cloud Configuration found. Creating Prefect Local named 'echodataflow-local'. Please add your prefect cloud ")
+        print(
+            "\nNo Prefect Cloud Configuration found. Creating Prefect Local named 'echodataflow-local'. Please add your prefect cloud "
+        )
         # Add local profile to echodataflow config but keep default as active since user might configure using Prefect setup
-        echodataflow_create_prefect_profile(
-            name="echodataflow-local", set_active=False)
+        echodataflow_create_prefect_profile(name="echodataflow-local", set_active=False)
     print("\nConfiguration Check Completed")
 
     print("\nChecking Connection to Prefect Server")
@@ -250,10 +251,9 @@ def echodataflow_start(
                 "Please connect to internet or consider switching to a local prefect environment. This can be done by calling load_profile(name_of_local_prefect_profile or 'echodataflow-local' if no prefect profile was created) method."
             )
         else:
-            print("\nUsing a local prefect environment. To go back to your cloud workspace call load_profile(<name>) with <name> of your cloud profile.")
-
-    if isinstance(storage_options, Block):
-        storage_options = get_storage_options(storage_options=storage_options)
+            print(
+                "\nUsing a local prefect environment. To go back to your cloud workspace call load_profile(<name>) with <name> of your cloud profile."
+            )
 
     print("\nStarting the Pipeline")
     # Call the actual pipeline
@@ -263,7 +263,7 @@ def echodataflow_start(
         logging_config=logging_config,
         storage_options=storage_options,
         options=options,
-        json_data_path=json_data_path
+        json_data_path=json_data_path,
     )
 
 
@@ -318,7 +318,6 @@ def update_prefect_config(
         if isinstance(current_config, Coroutine):
             current_config = asyncio.run(current_config)
         if current_config.prefect_configs is not None:
-
             if active_profile is None:
                 active_profile = current_config.active
 
@@ -329,9 +328,9 @@ def update_prefect_config(
                     profiles.remove(p)
             profiles.append(profile_name)
 
-        ecfg = EchodataflowConfig(active=active_profile, prefect_configs=profiles, blocks=current_config.blocks).save(
-            "echodataflow-config", overwrite=True
-        )
+        ecfg = EchodataflowConfig(
+            active=active_profile, prefect_configs=profiles, blocks=current_config.blocks
+        ).save("echodataflow-config", overwrite=True)
         if isinstance(ecfg, Coroutine):
             ecfg = asyncio.run(ecfg)
     except ValueError as e:
@@ -343,7 +342,9 @@ def update_prefect_config(
     return ecfg
 
 
-def update_base_config(name: str, b_type: StorageType, active: bool = False, options: Dict[str, Any] = {}):
+def update_base_config(
+    name: str, b_type: StorageType, active: bool = False, options: Dict[str, Any] = {}
+):
     """
     Update or create a base configuration in the echodataflow configuration block.
 
@@ -365,8 +366,7 @@ def update_base_config(name: str, b_type: StorageType, active: bool = False, opt
             options={"option_key": "option_value"}
         )
     """
-    aws_base = BaseConfig(name=name, type=b_type,
-                          active=active, options=options)
+    aws_base = BaseConfig(name=name, type=b_type, active=active, options=options)
     ecfg: Any = None
     try:
         blocks: List[BaseConfig] = []
@@ -402,7 +402,7 @@ def echodataflow_config_AWS(
     region_name: str = None,
     options: Union[str, Dict[str, Any]] = {},
     active: bool = False,
-    **kwargs
+    **kwargs,
 ):
     """
     Configure AWS credentials in the echodataflow configuration block.
@@ -438,8 +438,7 @@ def echodataflow_config_AWS(
         coro = asyncio.run(coro)
     if isinstance(options, str):
         options = json.loads(options)
-    update_base_config(name=name, active=active,
-                       options=options, b_type=StorageType.AWS)
+    update_base_config(name=name, active=active, options=options, b_type=StorageType.AWS)
 
 
 def echodataflow_config_AZ_cosmos(
@@ -447,7 +446,7 @@ def echodataflow_config_AZ_cosmos(
     connection_string: str = None,
     options: Union[str, Dict[str, Any]] = {},
     active: bool = False,
-    **kwargs
+    **kwargs,
 ):
     """
     Configure Azure Cosmos DB credentials in the local configuration file.
@@ -472,15 +471,12 @@ def echodataflow_config_AZ_cosmos(
     """
     if connection_string is None:
         raise ValueError("Connection string cannot be empty.")
-    coro = AzureCosmosDbCredentials(
-        connection_string=connection_string
-    ).save(name, overwrite=True)
+    coro = AzureCosmosDbCredentials(connection_string=connection_string).save(name, overwrite=True)
     if isinstance(coro, Coroutine):
         coro = asyncio.run(coro)
     if isinstance(options, str):
         options = json.loads(options)
-    update_base_config(name=name, active=active,
-                       options=options, b_type=StorageType.AZCosmos)
+    update_base_config(name=name, active=active, options=options, b_type=StorageType.AZCosmos)
 
 
 def load_credential_configuration(sync: bool = False):
@@ -533,20 +529,17 @@ def load_credential_configuration(sync: bool = False):
     if sync:
         current_config: EchodataflowConfig = None
         try:
-            current_config = EchodataflowConfig.load(
-                "echodataflow-config", validate=False)
+            current_config = EchodataflowConfig.load("echodataflow-config", validate=False)
             if isinstance(current_config, Coroutine):
                 current_config = asyncio.run(current_config)
             if current_config is not None:
-
                 for base in current_config.blocks:
-
                     block = load_block(base.name, base.type)
                     block_dict = dict(block)
-                    block_dict['name'] = base.name
-                    block_dict['active'] = base.active
-                    block_dict['options'] = json.dumps(base.options)
-                    block_dict['provider'] = base.type
+                    block_dict["name"] = base.name
+                    block_dict["active"] = base.active
+                    block_dict["options"] = json.dumps(base.options)
+                    block_dict["provider"] = base.type
                     converted_dict = {}
                     for key, value in block_dict.items():
                         if isinstance(value, SecretStr):
@@ -560,10 +553,10 @@ def load_credential_configuration(sync: bool = False):
         except ValueError:
             raise ("No Echodataflow configuration found.")
     for section in config.sections():
-        provider = config.get(section, 'provider')
+        provider = config.get(section, "provider")
         data_dict = dict(config[section])
-        data_dict['name'] = section
-        data_dict.pop('provider')
+        data_dict["name"] = section
+        data_dict.pop("provider")
         if provider == "AWS":
             echodataflow_config_AWS(**data_dict)
         elif provider == "AZCosmos":

--- a/echodataflow/stages/echodataflow_trigger.py
+++ b/echodataflow/stages/echodataflow_trigger.py
@@ -22,6 +22,7 @@ from fastapi.encoders import jsonable_encoder
 from prefect import flow
 from prefect.task_runners import SequentialTaskRunner
 from prefect.blocks.core import Block
+from prefect.variables import Variable
 
 from echodataflow.aspects.singleton_echodataflow import Singleton_Echodataflow
 from echodataflow.models.datastore import Dataset
@@ -215,10 +216,20 @@ def echodataflow_trigger(
     print("\nInitiliazing Singleton Object")
     Singleton_Echodataflow(log_file=logging_config_dict, pipeline=pipeline, dataset=dataset)
 
+    if dataset.args.parameters.file_name == "VAR_RUN_NAME":
+        var: Variable = Variable.get("run_name", default=None)
+        if not var:
+            raise ValueError("No variable found for name `run_name`")
+        else:
+            dataset.args.parameters.file_name = var.value
+
     # Change made to enable dynamic execution using an extension
     if options and options.get("file_name"):
         dataset.args.parameters.file_name = options.get("file_name")
 
+    if options and options.get("run_name"):
+        dataset.name = options.get("run_name")
+    
     print("\nReading Configurations")
     return init_flow(config=dataset, pipeline=pipeline, json_data_path=json_data_path)
 

--- a/echodataflow/stages/subflows/add_depth.py
+++ b/echodataflow/stages/subflows/add_depth.py
@@ -113,7 +113,7 @@ def process_add_depth(ed: EchodataflowObject, config: Dataset, stage: Stage, wor
         print(" Output :", add_depth_output)
     """
 
-    file_name = ed.filename + "_add depth.zarr"
+    file_name = ed.filename + "_depth.zarr"
 
     try:
         log_util.log(
@@ -161,10 +161,7 @@ def process_add_depth(ed: EchodataflowObject, config: Dataset, stage: Stage, wor
                 eflogging=config.logging,
             )
             
-            if stage.external_params:
-                external_kwargs = stage.external_params                
-            else:
-                external_kwargs = None
+            external_kwargs = stage.external_params                
                 
             xr_d = ep.consolidate.add_depth(
                 ds=ed_list[0],
@@ -201,7 +198,13 @@ def process_add_depth(ed: EchodataflowObject, config: Dataset, stage: Stage, wor
         )
         ed.out_path = out_zarr
         ed.error = ErrorObject(errorFlag=False)
+        ed.stages[stage.name] = out_zarr
     except Exception as e:
+        log_util.log(
+            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:
         return ed

--- a/echodataflow/stages/subflows/add_depth.py
+++ b/echodataflow/stages/subflows/add_depth.py
@@ -201,9 +201,10 @@ def process_add_depth(ed: EchodataflowObject, config: Dataset, stage: Stage, wor
         ed.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:

--- a/echodataflow/stages/subflows/add_depth.py
+++ b/echodataflow/stages/subflows/add_depth.py
@@ -26,7 +26,7 @@ from echodataflow.models.datastore import Dataset
 from echodataflow.models.output_model import EchodataflowObject, ErrorObject, Group
 from echodataflow.models.pipeline import Stage
 from echodataflow.utils import log_util
-from echodataflow.utils.file_utils import get_ed_list, get_out_zarr, get_working_dir, isFile
+from echodataflow.utils.file_utils import get_out_zarr, get_working_dir, get_zarr_list, isFile
 
 
 @flow
@@ -153,19 +153,22 @@ def process_add_depth(ed: EchodataflowObject, config: Dataset, stage: Stage, wor
                 eflogging=config.logging,
             )
 
-            ed_list = get_ed_list.fn(config=config, stage=stage, transect_data=ed)
+            ed_list = get_zarr_list.fn(transect_data=ed, storage_options=config.output.storage_options_dict)
 
             log_util.log(
                 msg={"msg": f"Computing SV", "mod_name": __file__, "func_name": file_name},
                 use_dask=stage.options["use_dask"],
                 eflogging=config.logging,
             )
-
+            
+            if stage.external_params:
+                external_kwargs = stage.external_params                
+            else:
+                external_kwargs = None
+                
             xr_d = ep.consolidate.add_depth(
                 ds=ed_list[0],
-                depth_offset=stage.external_params.get("depth_offset"),
-                tilt=stage.external_params.get("tilt"),
-                downward=stage.external_params.get("downward"),
+                **external_kwargs
             )
 
             log_util.log(

--- a/echodataflow/stages/subflows/add_location.py
+++ b/echodataflow/stages/subflows/add_location.py
@@ -26,7 +26,7 @@ from echodataflow.models.datastore import Dataset
 from echodataflow.models.output_model import EchodataflowObject, ErrorObject, Group
 from echodataflow.models.pipeline import Stage
 from echodataflow.utils import log_util
-from echodataflow.utils.file_utils import get_ed_list, get_out_zarr, get_working_dir, isFile
+from echodataflow.utils.file_utils import get_out_zarr, get_working_dir, get_zarr_list, isFile
 
 
 @flow
@@ -155,18 +155,22 @@ def process_add_location(ed: EchodataflowObject, config: Dataset, stage: Stage, 
                 eflogging=config.logging,
             )
 
-            ed_list = get_ed_list.fn(config=config, stage=stage, transect_data=ed)
+            ed_list = get_zarr_list.fn(transect_data=ed, storage_options=config.output.storage_options_dict)
 
             log_util.log(
                 msg={"msg": f"Computing SV", "mod_name": __file__, "func_name": file_name},
                 use_dask=stage.options["use_dask"],
                 eflogging=config.logging,
             )
-
+            
+            if stage.external_params:
+                external_kwargs = stage.external_params                
+            else:
+                external_kwargs = None
+                
             xr_d = ep.consolidate.add_location(
                 ds=ed_list[0],
-                echodata=stage.external_params.get("echodata"),
-                nmea_sentence=stage.external_params.get("nmea_sentence"),
+                **external_kwargs
             )
 
             log_util.log(

--- a/echodataflow/stages/subflows/add_location.py
+++ b/echodataflow/stages/subflows/add_location.py
@@ -210,9 +210,10 @@ def process_add_location(ed: EchodataflowObject, config: Dataset, stage: Stage, 
         ed.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:

--- a/echodataflow/stages/subflows/apply_mask.py
+++ b/echodataflow/stages/subflows/apply_mask.py
@@ -231,9 +231,10 @@ def process_apply_mask(ed: EchodataflowObject, config: Dataset, stage: Stage, wo
         ed.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:

--- a/echodataflow/stages/subflows/apply_mask.py
+++ b/echodataflow/stages/subflows/apply_mask.py
@@ -187,11 +187,17 @@ def process_apply_mask(ed: EchodataflowObject, config: Dataset, stage: Stage, wo
                 ed_list[0] = ed_list[0].swap_dims({"echo_range": "range_sample"}).rename_vars({"echo_range": "range_sample"})
                 mask = mask.swap_dims({"echo_range": "range_sample"})
             
+            if stage.external_params:
+                external_kwargs = stage.external_params                
+            else:
+                external_kwargs = None
+                
             xr_d = apply_mask(
                 source_ds=ed_list[0],
                 mask=mask,
                 storage_options_ds=config.output.storage_options_dict,
                 storage_options_mask=config.output.storage_options_dict,
+                **external_kwargs
             )
             log_util.log(
                 msg={"msg": f"Converting to Zarr", "mod_name": __file__, "func_name": file_name},

--- a/echodataflow/stages/subflows/combine_echodata.py
+++ b/echodataflow/stages/subflows/combine_echodata.py
@@ -165,8 +165,12 @@ def process_combine_echodata(group: Group, config: Dataset, stage: Stage, workin
                 use_dask=stage.options["use_dask"],
                 eflogging=config.logging,
             )
-
-            ceds = combine_echodata(echodata_list=ed_list)
+            if stage.external_params:
+                external_kwargs = stage.external_params                
+            else:
+                external_kwargs = None
+                
+            ceds = combine_echodata(echodata_list=ed_list, **external_kwargs)
 
             log_util.log(
                 msg={"msg": f"Converting to Zarr", "mod_name": __file__, "func_name": file_name},

--- a/echodataflow/stages/subflows/combine_echodata.py
+++ b/echodataflow/stages/subflows/combine_echodata.py
@@ -207,9 +207,10 @@ def process_combine_echodata(group: Group, config: Dataset, stage: Stage, workin
         ed.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         ed = group.data[0]
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))

--- a/echodataflow/stages/subflows/combine_echodata.py
+++ b/echodataflow/stages/subflows/combine_echodata.py
@@ -165,10 +165,8 @@ def process_combine_echodata(group: Group, config: Dataset, stage: Stage, workin
                 use_dask=stage.options["use_dask"],
                 eflogging=config.logging,
             )
-            if stage.external_params:
-                external_kwargs = stage.external_params                
-            else:
-                external_kwargs = None
+            
+            external_kwargs = stage.external_params                
                 
             ceds = combine_echodata(echodata_list=ed_list, **external_kwargs)
 
@@ -206,7 +204,13 @@ def process_combine_echodata(group: Group, config: Dataset, stage: Stage, workin
         ed.out_path = out_zarr
         ed.error = ErrorObject(errorFlag=False)
         group.data = [ed]
+        ed.stages[stage.name] = out_zarr
     except Exception as e:
+        log_util.log(
+            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
         ed = group.data[0]
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:

--- a/echodataflow/stages/subflows/compute_MVBS.py
+++ b/echodataflow/stages/subflows/compute_MVBS.py
@@ -167,10 +167,7 @@ def process_compute_mvbs(ed: EchodataflowObject, config: Dataset, stage: Stage, 
                 eflogging=config.logging,
             )
 
-            if stage.external_params:
-                external_kwargs = stage.external_params                
-            else:
-                external_kwargs = None                      
+            external_kwargs = stage.external_params                
             
             xr_d_mvbs: xr.Dataset = ep.commongrid.compute_MVBS(
                 ds_Sv=ed_list[0],
@@ -207,7 +204,13 @@ def process_compute_mvbs(ed: EchodataflowObject, config: Dataset, stage: Stage, 
         )
         ed.out_path = out_zarr
         ed.error = ErrorObject(errorFlag=False)
+        ed.stages[stage.name] = out_zarr
     except Exception as e:
+        log_util.log(
+            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:
         return ed

--- a/echodataflow/stages/subflows/compute_MVBS.py
+++ b/echodataflow/stages/subflows/compute_MVBS.py
@@ -207,9 +207,10 @@ def process_compute_mvbs(ed: EchodataflowObject, config: Dataset, stage: Stage, 
         ed.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:

--- a/echodataflow/stages/subflows/compute_MVBS.py
+++ b/echodataflow/stages/subflows/compute_MVBS.py
@@ -168,16 +168,13 @@ def process_compute_mvbs(ed: EchodataflowObject, config: Dataset, stage: Stage, 
             )
 
             if stage.external_params:
-                range_bin = stage.external_params.get("range_meter_bin", None)
-                ping_time_bin = stage.external_params.get("ping_time_bin", None)
+                external_kwargs = stage.external_params                
             else:
-                range_bin = None
-                ping_time_bin = None                          
+                external_kwargs = None                      
             
             xr_d_mvbs: xr.Dataset = ep.commongrid.compute_MVBS(
                 ds_Sv=ed_list[0],
-                range_bin=range_bin,
-                ping_time_bin=ping_time_bin,
+                **external_kwargs
             )
             log_util.log(
                 msg={"msg": f"Converting to Zarr", "mod_name": __file__, "func_name": file_name},

--- a/echodataflow/stages/subflows/compute_NASC.py
+++ b/echodataflow/stages/subflows/compute_NASC.py
@@ -1,0 +1,215 @@
+
+"""
+Echodataflow Compute_nasc Task
+
+This module defines a Prefect Flow and associated tasks for the Echodataflow Compute_nasc stage.
+
+Classes:
+    None
+
+Functions:
+    echodataflow_compute_NASC(config: Dataset, stage: Stage, data: Union[str, List[Output]])
+    process_compute_NASC(config: Dataset, stage: Stage, out_data: Union[List[Dict], List[Output]], working_dir: str)
+
+Author: Soham Butala
+Email: sbutala@uw.edu
+Date: August 22, 2023
+"""
+from collections import defaultdict
+from typing import Dict, Optional
+
+import echopype as ep
+from prefect import flow, task
+
+from echodataflow.aspects.echodataflow_aspect import echodataflow
+from echodataflow.models.datastore import Dataset
+from echodataflow.models.output_model import EchodataflowObject, ErrorObject, Group
+from echodataflow.models.pipeline import Stage
+from echodataflow.utils import log_util
+from echodataflow.utils.file_utils import get_ed_list, get_out_zarr, get_working_dir, get_zarr_list, isFile
+
+
+@flow
+@echodataflow(processing_stage="compute-NASC", type="FLOW")
+def echodataflow_compute_NASC(
+        groups: Dict[str, Group], config: Dataset, stage: Stage, prev_stage: Optional[Stage]
+):
+    """
+    compute NASC from echodata.
+
+    Args:
+        config (Dataset): Configuration for the dataset being processed.
+        stage (Stage): Configuration for the current processing stage.
+        prev_stage (Stage): Configuration for the previous processing stage.
+
+    Returns:
+        List[Output]: List of The input dataset with the compute NASC data added.
+
+    Example:
+        # Define configuration and data
+        dataset_config = ...
+        pipeline_stage = ...
+        echodata_outputs = ...
+
+        # Execute the Echodataflow compute_NASC stage
+        compute_NASC_output = echodataflow_compute_NASC(
+            config=dataset_config,
+            stage=pipeline_stage,
+            data=echodata_outputs
+        )
+        print("Output :", compute_NASC_output)
+    """
+    working_dir = get_working_dir(stage=stage, config=config)
+
+    futures = defaultdict(list)
+
+    for name, gr in groups.items():
+        for ed in gr.data:
+            gname = ed.out_path.split(".")[0] + ".Computenasc"
+            new_process = process_compute_NASC.with_options(
+                task_run_name=gname, name=gname, retries=3
+                    )
+            future = new_process.submit(
+                ed=ed, working_dir=working_dir, config=config, stage=stage
+                )
+            futures[name].append(future)
+
+    for name, flist in futures.items():
+        try:
+            groups[name].data = [f.result() for f in flist]
+        except Exception as e:
+            groups[name].data[0].error = ErrorObject(errorFlag=True, error_desc=str(e))
+
+    return groups
+
+
+@task
+@echodataflow()
+def process_compute_NASC(
+    ed: EchodataflowObject, config: Dataset, stage: Stage, working_dir: str
+):
+    """
+    Process and compute NASC from Echodata object into the dataset.
+
+    Args:
+        config (Dataset): Configuration for the dataset being processed.
+        stage (Stage): Configuration for the current processing stage.
+        out_data (Union[Dict, Output]): Processed outputs (xr.Dataset) to compute NASC.
+        working_dir (str): Working directory for processing.
+
+    Returns:
+        The input dataset with the compute NASC data added
+
+    Example:
+        # Define configuration, processed data, and working directory
+        dataset_config = ...
+        pipeline_stage = ...
+        processed_outputs = ...
+        working_directory = ...
+
+        # Process and compute NASC
+        compute_NASC_output = process_compute_NASC(
+            config=dataset_config,
+            stage=pipeline_stage,
+            out_data=processed_outputs,
+            working_dir=working_directory
+        )
+        print(" Output :", compute_NASC_output)
+    """
+
+    file_name = ed.filename + "_NASC.zarr"
+
+    try:
+        log_util.log(
+            msg={"msg": " ---- Entering ----", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
+
+        out_zarr = get_out_zarr(
+            group=stage.options.get("group", True),
+            working_dir=working_dir,
+            transect=ed.group_name,
+            file_name=file_name,
+            storage_options=config.output.storage_options_dict,
+        )
+
+        log_util.log(
+            msg={
+                "msg": f"Processing file, output will be at {out_zarr}",
+                "mod_name": __file__,
+                "func_name": file_name,
+            },
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
+
+        if (
+            stage.options.get("use_offline") == False
+            or isFile(out_zarr, config.output.storage_options_dict) == False
+        ):
+            log_util.log(
+                msg={
+                    "msg": f"File not found in the destination folder / use_offline flag is False",
+                    "mod_name": __file__,
+                    "func_name": file_name,
+                },
+                use_dask=stage.options["use_dask"],
+                eflogging=config.logging,
+            )
+
+            ed_list = get_zarr_list.fn(transect_data=ed, storage_options=config.output.storage_options_dict)
+
+            log_util.log(
+                msg={"msg": 'Computing compute_NASC', "mod_name": __file__, "func_name": file_name},
+                use_dask=stage.options["use_dask"],
+                eflogging=config.logging,
+            )
+
+            external_kwargs = stage.external_params
+
+            xr_d = ep.commongrid.compute_NASC(
+                ds_Sv=ed_list[0],
+                **external_kwargs
+            )
+
+            log_util.log(
+                msg={"msg": f"Converting to Zarr", "mod_name": __file__, "func_name": file_name},
+                use_dask=stage.options["use_dask"],
+                eflogging=config.logging,
+            )
+
+            xr_d.to_zarr(
+                store=out_zarr,
+                mode="w",
+                consolidated=True,
+                storage_options=config.output.storage_options_dict,
+            )
+        else:
+            log_util.log(
+                msg={
+                    "msg": f"Skipped processing {file_name}. File found in the destination folder. To replace or reprocess set `use_offline` flag to False",
+                    "mod_name": __file__,
+                    "func_name": file_name,
+                },
+                use_dask=stage.options["use_dask"],
+                eflogging=config.logging,
+            )
+
+        log_util.log(
+            msg={"msg": f" ---- Exiting ----", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
+        ed.out_path = out_zarr
+        ed.error = ErrorObject(errorFlag=False)
+        ed.stages[stage.name] = out_zarr
+    except Exception as e:
+        log_util.log(
+            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
+        ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
+    finally:
+        return ed

--- a/echodataflow/stages/subflows/compute_NASC.py
+++ b/echodataflow/stages/subflows/compute_NASC.py
@@ -206,9 +206,10 @@ def process_compute_NASC(
         ed.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:

--- a/echodataflow/stages/subflows/compute_Sv.py
+++ b/echodataflow/stages/subflows/compute_Sv.py
@@ -202,9 +202,10 @@ def process_compute_sv(ed: EchodataflowObject, config: Dataset, stage: Stage, wo
         ed.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:

--- a/echodataflow/stages/subflows/compute_Sv.py
+++ b/echodataflow/stages/subflows/compute_Sv.py
@@ -166,14 +166,11 @@ def process_compute_sv(ed: EchodataflowObject, config: Dataset, stage: Stage, wo
             )
 
             if stage.external_params:
-                wave_mode = stage.external_params.get("waveform_mode", None)
-                encode_mode = stage.external_params.get("encode_mode", None)
+                external_kwargs = stage.external_params                
             else:
-                wave_mode = None
-                encode_mode = None
+                external_kwargs = None
                 
-            xr_d_sv = ep.calibrate.compute_Sv(echodata=ed_list[0],  waveform_mode= wave_mode, 
-               encode_mode = encode_mode)
+            xr_d_sv = ep.calibrate.compute_Sv(echodata=ed_list[0], **external_kwargs)
 
             log_util.log(
                 msg={"msg": f"Converting to Zarr", "mod_name": __file__, "func_name": file_name},

--- a/echodataflow/stages/subflows/compute_Sv.py
+++ b/echodataflow/stages/subflows/compute_Sv.py
@@ -165,7 +165,15 @@ def process_compute_sv(ed: EchodataflowObject, config: Dataset, stage: Stage, wo
                 eflogging=config.logging,
             )
 
-            xr_d_sv = ep.calibrate.compute_Sv(echodata=ed_list[0])
+            if stage.external_params:
+                wave_mode = stage.external_params.get("waveform_mode", None)
+                encode_mode = stage.external_params.get("encode_mode", None)
+            else:
+                wave_mode = None
+                encode_mode = None
+                
+            xr_d_sv = ep.calibrate.compute_Sv(echodata=ed_list[0],  waveform_mode= wave_mode, 
+               encode_mode = encode_mode)
 
             log_util.log(
                 msg={"msg": f"Converting to Zarr", "mod_name": __file__, "func_name": file_name},

--- a/echodataflow/stages/subflows/compute_Sv.py
+++ b/echodataflow/stages/subflows/compute_Sv.py
@@ -165,10 +165,7 @@ def process_compute_sv(ed: EchodataflowObject, config: Dataset, stage: Stage, wo
                 eflogging=config.logging,
             )
 
-            if stage.external_params:
-                external_kwargs = stage.external_params                
-            else:
-                external_kwargs = None
+            external_kwargs = stage.external_params                
                 
             xr_d_sv = ep.calibrate.compute_Sv(echodata=ed_list[0], **external_kwargs)
 
@@ -202,7 +199,13 @@ def process_compute_sv(ed: EchodataflowObject, config: Dataset, stage: Stage, wo
         )
         ed.out_path = out_zarr
         ed.error = ErrorObject(errorFlag=False)
+        ed.stages[stage.name] = out_zarr
     except Exception as e:
+        log_util.log(
+            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:
         return ed

--- a/echodataflow/stages/subflows/compute_TS.py
+++ b/echodataflow/stages/subflows/compute_TS.py
@@ -169,7 +169,12 @@ def process_compute_ts(ed: EchodataflowObject, config: Dataset, stage: Stage, wo
                 eflogging=config.logging,
             )
 
-            xr_d_ts = ep.calibrate.compute_TS(echodata=ed_list[0])
+            if stage.external_params:
+                external_kwargs = stage.external_params                
+            else:
+                external_kwargs = None
+                
+            xr_d_ts = ep.calibrate.compute_TS(echodata=ed_list[0], **external_kwargs)
 
             log_util.log(
                 msg={"msg": f"Converting to Zarr", "mod_name": __file__, "func_name": file_name},

--- a/echodataflow/stages/subflows/compute_TS.py
+++ b/echodataflow/stages/subflows/compute_TS.py
@@ -206,9 +206,10 @@ def process_compute_ts(ed: EchodataflowObject, config: Dataset, stage: Stage, wo
         ed.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:

--- a/echodataflow/stages/subflows/compute_TS.py
+++ b/echodataflow/stages/subflows/compute_TS.py
@@ -169,10 +169,7 @@ def process_compute_ts(ed: EchodataflowObject, config: Dataset, stage: Stage, wo
                 eflogging=config.logging,
             )
 
-            if stage.external_params:
-                external_kwargs = stage.external_params                
-            else:
-                external_kwargs = None
+            external_kwargs = stage.external_params                
                 
             xr_d_ts = ep.calibrate.compute_TS(echodata=ed_list[0], **external_kwargs)
 
@@ -206,7 +203,13 @@ def process_compute_ts(ed: EchodataflowObject, config: Dataset, stage: Stage, wo
         )
         ed.out_path = out_zarr
         ed.error = ErrorObject(errorFlag=False)
+        ed.stages[stage.name] = out_zarr
     except Exception as e:
+        log_util.log(
+            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:
         return ed

--- a/echodataflow/stages/subflows/frequency_differencing.py
+++ b/echodataflow/stages/subflows/frequency_differencing.py
@@ -218,9 +218,10 @@ def process_frequency_differencing(
         ed.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:

--- a/echodataflow/stages/subflows/frequency_differencing.py
+++ b/echodataflow/stages/subflows/frequency_differencing.py
@@ -174,11 +174,15 @@ def process_frequency_differencing(
                 use_dask=stage.options["use_dask"],
                 eflogging=config.logging,
             )
-
+            if stage.external_params:
+                external_kwargs = stage.external_params                
+            else:
+                external_kwargs = None
+                
             xr_d = ep.mask.frequency_differencing(
                 source_Sv=ed_list[0],
-                freqABEq=stage.external_params.get("freqABEq"),
                 storage_options=config.output.storage_options_dict,
+                **external_kwargs
             )
 
             log_util.log(

--- a/echodataflow/stages/subflows/frequency_differencing.py
+++ b/echodataflow/stages/subflows/frequency_differencing.py
@@ -174,10 +174,8 @@ def process_frequency_differencing(
                 use_dask=stage.options["use_dask"],
                 eflogging=config.logging,
             )
-            if stage.external_params:
-                external_kwargs = stage.external_params                
-            else:
-                external_kwargs = None
+            
+            external_kwargs = stage.external_params                
                 
             xr_d = ep.mask.frequency_differencing(
                 source_Sv=ed_list[0],
@@ -217,7 +215,13 @@ def process_frequency_differencing(
 
         ed.stages["mask"] = out_zarr
         ed.error = ErrorObject(errorFlag=False)
+        ed.stages[stage.name] = out_zarr
     except Exception as e:
+        log_util.log(
+            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
         ed.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:
         return ed

--- a/echodataflow/stages/subflows/initialization_flow.py
+++ b/echodataflow/stages/subflows/initialization_flow.py
@@ -170,6 +170,9 @@ def process_stages_disk(
             client.forward_logging("echodataflow_logs")
             stage.options["use_dask"] = True
 
+        if not stage.external_params:
+            stage.external_params = {}
+        
         if not sanitize_external_params(config, stage.external_params):
             raise ValueError(
                 "Sanity Check Failed. One or more external parameters passed have a problem."

--- a/echodataflow/stages/subflows/initialization_flow.py
+++ b/echodataflow/stages/subflows/initialization_flow.py
@@ -136,8 +136,11 @@ def process_stages_disk(
                 msg={"msg": f"{client}", "mod_name": __file__, "func_name": "Init Flow"},
                 eflogging=config.logging,
             )
-            client.forward_logging("echodataflow")
             stage.options["use_dask"] = True
+            gea = Singleton_Echodataflow().get_instance()
+            
+            if gea.logger:
+                client.subscribe_topic("echodataflow", lambda event: log_util.log_event(event=event))
         elif (
             pipeline.use_local_dask == True
             and prefect_config_dict is not None
@@ -167,8 +170,11 @@ def process_stages_disk(
                 },
                 eflogging=config.logging,
             )
-            client.forward_logging("echodataflow_logs")
             stage.options["use_dask"] = True
+            gea = Singleton_Echodataflow().get_instance()
+            
+            if gea.logger:
+                client.subscribe_topic("echodataflow", lambda event: log_util.log_event(event))
 
         if not stage.external_params:
             stage.external_params = {}
@@ -242,8 +248,6 @@ def process_stages_disk(
                     cleanup(config, prev_stage)
 
         prev_stage = stage
-
-    log_util.log_stream()
 
     # Close the local cluster but not the cluster hosted.
     if pipeline.scheduler_address is None and pipeline.use_local_dask == True:

--- a/echodataflow/stages/subflows/initialization_flow.py
+++ b/echodataflow/stages/subflows/initialization_flow.py
@@ -220,6 +220,8 @@ def process_stages_disk(
         groups = process_output_groups(
             name=stage.name, stage=stage, config=config, groups=groups, error_groups=error_groups
         )
+        output.group = groups
+        
         store_json_output(data=output, name=stage.name + "_output", config=config)
 
         store_json_output(data=error_groups, name=stage.name + "_ErroredGroups", config=config)
@@ -232,20 +234,6 @@ def process_stages_disk(
             },
             eflogging=config.logging,
         )
-
-        if prev_stage is not None:
-            if config.output.retention == False:
-                if (
-                    prev_stage.options.get("save_offline") is None
-                    or prev_stage.options.get("save_offline") == False
-                ):
-                    cleanup(config, prev_stage)
-            else:
-                if (
-                    prev_stage.options.get("save_offline") is not None
-                    and prev_stage.options.get("save_offline") == False
-                ):
-                    cleanup(config, prev_stage)
 
         prev_stage = stage
 
@@ -261,6 +249,8 @@ def process_stages_disk(
             eflogging=config.logging,
         )
 
+    cleanup(output=output, config=config, pipeline=active_pipeline)
+    
     # Incase where the output is too big, this call might be expensive and not feasible on
     # systems with low memory, commenting the call.
     # output = get_last_run_output(data=output, storage_options=config.output.storage_options_dict)

--- a/echodataflow/stages/subflows/initialization_flow.py
+++ b/echodataflow/stages/subflows/initialization_flow.py
@@ -46,7 +46,7 @@ from echodataflow.utils.file_utils import (
 from echodataflow.utils.function_utils import dynamic_function_call
 
 
-@flow(name="Init-Flow", task_runner=SequentialTaskRunner())
+@flow(name="Initialization", task_runner=SequentialTaskRunner())
 @echodataflow(type="FLOW")
 def init_flow(pipeline: Recipe, config: Dataset, json_data_path: Optional[str] = None):
     """

--- a/echodataflow/stages/subflows/mask_prediction.py
+++ b/echodataflow/stages/subflows/mask_prediction.py
@@ -1,0 +1,303 @@
+
+"""
+Echodataflow Mask_prediction Task
+
+This module defines a Prefect Flow and associated tasks for the Echodataflow Mask_prediction stage.
+
+Classes:
+    None
+
+Functions:
+    echodataflow_mask_prediction(config: Dataset, stage: Stage, data: Union[str, List[Output]])
+    process_mask_prediction(config: Dataset, stage: Stage, out_data: Union[List[Dict], List[Output]], working_dir: str)
+
+Author: Soham Butala
+Email: sbutala@uw.edu
+Date: August 22, 2023
+"""
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Optional, Union
+
+import echopype as ep
+from prefect import flow, task
+import torch
+import xarray as xr
+import numpy as np
+
+from echodataflow.aspects.echodataflow_aspect import echodataflow
+from echodataflow.models.datastore import Dataset
+from echodataflow.models.output_model import EchodataflowObject, ErrorObject, Group, Output
+from echodataflow.models.pipeline import Stage
+from echodataflow.utils import log_util
+from echodataflow.utils.file_utils import get_ed_list, get_out_zarr, get_working_dir, get_zarr_list, isFile
+from src.model.BinaryHakeModel import BinaryHakeModel
+
+
+@flow
+@echodataflow(processing_stage="mask-prediction", type="FLOW")
+def echodataflow_mask_prediction(
+        groups: Dict[str, Group], config: Dataset, stage: Stage, prev_stage: Optional[Stage]
+):
+    """
+    mask prediction from echodata.
+
+    Args:
+        config (Dataset): Configuration for the dataset being processed.
+        stage (Stage): Configuration for the current processing stage.
+        prev_stage (Stage): Configuration for the previous processing stage.
+
+    Returns:
+        List[Output]: List of The input dataset with the mask prediction data added.
+
+    Example:
+        # Define configuration and data
+        dataset_config = ...
+        pipeline_stage = ...
+        echodata_outputs = ...
+
+        # Execute the Echodataflow mask_prediction stage
+        mask_prediction_output = echodataflow_mask_prediction(
+            config=dataset_config,
+            stage=pipeline_stage,
+            data=echodata_outputs
+        )
+        print("Output :", mask_prediction_output)
+    """
+    working_dir = get_working_dir(stage=stage, config=config)
+
+    futures = defaultdict(list)
+
+    for name, gr in groups.items():
+        for ed in gr.data:
+            gname = ed.out_path.split(".")[0] + ".MaskPrediction"
+            new_process = process_mask_prediction.with_options(
+                task_run_name=gname, name=gname, retries=3
+                    )
+            future = new_process.submit(
+                ed=ed, working_dir=working_dir, config=config, stage=stage
+                )
+            futures[name].append(future)
+
+    for name, flist in futures.items():
+        try:
+            groups[name].data = [f.result() for f in flist]
+        except Exception as e:
+            groups[name].data[0].error = ErrorObject(errorFlag=True, error_desc=str(e))
+
+    return groups
+
+
+@task
+@echodataflow()
+def process_mask_prediction(
+    ed: EchodataflowObject, config: Dataset, stage: Stage, working_dir: str
+):
+    """
+    Process and mask prediction from Echodata object into the dataset.
+
+    Args:
+        config (Dataset): Configuration for the dataset being processed.
+        stage (Stage): Configuration for the current processing stage.
+        out_data (Union[Dict, Output]): Processed outputs (xr.Dataset) to mask prediction.
+        working_dir (str): Working directory for processing.
+
+    Returns:
+        The input dataset with the mask prediction data added
+
+    Example:
+        # Define configuration, processed data, and working directory
+        dataset_config = ...
+        pipeline_stage = ...
+        processed_outputs = ...
+        working_directory = ...
+
+        # Process and mask prediction
+        mask_prediction_output = process_mask_prediction(
+            config=dataset_config,
+            stage=pipeline_stage,
+            out_data=processed_outputs,
+            working_dir=working_directory
+        )
+        print(" Output :", mask_prediction_output)
+    """
+
+    file_name = ed.filename + "_mask.zarr"
+
+    try:
+        log_util.log(
+            msg={"msg": " ---- Entering ----", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
+
+        out_zarr = get_out_zarr(
+            group=stage.options.get("group", True),
+            working_dir=working_dir,
+            transect=ed.group_name,
+            file_name=file_name,
+            storage_options=config.output.storage_options_dict,
+        )
+
+        log_util.log(
+            msg={
+                "msg": f"Processing file, output will be at {out_zarr}",
+                "mod_name": __file__,
+                "func_name": file_name,
+            },
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
+
+        if (
+            stage.options.get("use_offline") == False
+            or isFile(out_zarr, config.output.storage_options_dict) == False
+        ):
+            log_util.log(
+                msg={
+                    "msg": f"File not found in the destination folder / use_offline flag is False",
+                    "mod_name": __file__,
+                    "func_name": file_name,
+                },
+                use_dask=stage.options["use_dask"],
+                eflogging=config.logging,
+            )
+
+            ed_list = get_zarr_list.fn(transect_data=ed, storage_options=config.output.storage_options_dict)
+
+            log_util.log(
+                msg={"msg": 'Computing mask_prediction', "mod_name": __file__, "func_name": file_name},
+                use_dask=stage.options["use_dask"],
+                eflogging=config.logging,
+            )
+
+            if not stage.external_params:
+                stage.external_params = {}
+            
+            bottom_offset = stage.external_params.get('bottom_offset', 1.0)
+            temperature = stage.external_params.get('temperature', 0.5)
+            freq_wanted = stage.external_params.get('freq_wanted', [18000, 38000, 12000])
+            
+            ch_wanted = [int((np.abs(ed_list[0]["frequency_nominal"]-freq)).argmin()) for freq in freq_wanted]
+
+            log_util.log(
+                msg={"msg": f"Channel order {ch_wanted}", "mod_name": __file__, "func_name": file_name},
+                use_dask=stage.options["use_dask"],
+                eflogging=config.logging,
+            )
+            
+            mvbs_slice = ed_list[0].isel(
+                channel=ch_wanted
+            )
+            
+            # Load binary hake models with weights
+            model = BinaryHakeModel("placeholder_experiment_name",
+                                    Path("placeholder_score_tensor_dir"),
+                                    "placeholder_tensor_log_dir", 0).eval()
+            model.load_state_dict(torch.load(f"/home/exouser/hake_data/Hake_ML/backup_model_weights/binary_hake_model_{bottom_offset}m_bottom_offset_1.0m_depth_2017_2019_ver_1.ckpt")["state_dict"])            
+            
+            mvbs_tensor = torch.tensor(mvbs_slice['Sv'].values, dtype=torch.float32).unsqueeze(0)
+
+            da_MVBS_tensor = torch.clip(
+                torch.tensor(mvbs_tensor, dtype=torch.float16),
+                min=-70,
+                max=-36,
+            )
+            # Replace NaN values with min Sv
+            da_MVBS_tensor[torch.isnan(da_MVBS_tensor)] = -36
+            
+            MVBS_tensor_normalized = (
+                (da_MVBS_tensor - (-70.0)) / (-36.0 - (-70.0)) * 255.0
+            )
+            input_tensor = MVBS_tensor_normalized.unsqueeze(0).float()
+            
+            score_tensor = model(input_tensor).detach().squeeze(0)
+            
+            log_util.log(
+                msg={"msg": f"Converting to Zarr", "mod_name": __file__, "func_name": file_name},
+                use_dask=stage.options["use_dask"],
+                eflogging=config.logging,
+            )
+
+            dims = ['ping_time', 'echo_range']
+            
+            softmax_score_tensor = torch.nn.functional.softmax(
+                score_tensor / temperature, dim=0
+            )
+            
+            da_score_hake = assemble_da(score_tensor.numpy()[1,:,:], ds_ref=ed_list[0], dims=dims)
+            da_softmax_hake = assemble_da(softmax_score_tensor.numpy()[1,:,:], ds_ref=ed_list[0], dims=dims)
+            
+            score_zarr = get_out_zarr(
+                group=True,
+                working_dir=working_dir,
+                transect="Hake_Score",
+                file_name=ed.filename + "_score_hake.zarr",
+                storage_options=config.output.storage_options_dict,
+            )
+            
+            softmax_zarr = get_out_zarr(
+                group=True,
+                working_dir=working_dir,
+                transect="Softmax_Score",
+                file_name=ed.filename + "_softmax_score.zarr",
+                storage_options=config.output.storage_options_dict,
+            )
+
+            # save scores 
+            da_score_hake.to_zarr(
+                store=score_zarr,
+                mode="w",
+                consolidated=True,
+                storage_options=config.output.storage_options_dict,
+                )
+            
+            da_softmax_hake.to_zarr(
+                store=softmax_zarr,
+                mode="w",
+                consolidated=True,
+                storage_options=config.output.storage_options_dict,
+                )
+            
+            # Get mask from softmax score
+            da_mask_hake = assemble_da(score_tensor.max(dim=0)[1].int().numpy(), ds_ref=ed_list[0], dims=dims)
+            
+            da_mask_hake.to_zarr(
+                store=out_zarr,
+                mode="w",
+                consolidated=True,
+                storage_options=config.output.storage_options_dict,
+            )
+            
+        else:
+            log_util.log(
+                msg={
+                    "msg": f"Skipped processing {file_name}. File found in the destination folder. To replace or reprocess set `use_offline` flag to False",
+                    "mod_name": __file__,
+                    "func_name": file_name,
+                },
+                use_dask=stage.options["use_dask"],
+                eflogging=config.logging,
+            )
+
+        log_util.log(
+            msg={"msg": f" ---- Exiting ----", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
+        ed.stages["mask"] = out_zarr
+        ed.error = ErrorObject(errorFlag=False)
+    except Exception as e:
+        ed.error = ErrorObject(errorFlag=True, error_desc=e)
+    finally:
+        return ed
+
+
+def assemble_da(data_array, ds_ref, dims):
+    da = xr.DataArray(
+        data_array, dims=dims
+    )
+    da = da.assign_coords(
+        {dim: ds_ref[dim] for dim in dims}
+    )
+    return da

--- a/echodataflow/stages/subflows/mask_prediction.py
+++ b/echodataflow/stages/subflows/mask_prediction.py
@@ -287,9 +287,10 @@ def process_mask_prediction(
         ed.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         ed.error = ErrorObject(errorFlag=True, error_desc=e)
     finally:

--- a/echodataflow/stages/subflows/mask_prediction.py
+++ b/echodataflow/stages/subflows/mask_prediction.py
@@ -17,9 +17,8 @@ Date: August 22, 2023
 """
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, Optional
 
-import echopype as ep
 from prefect import flow, task
 import torch
 import xarray as xr
@@ -27,10 +26,10 @@ import numpy as np
 
 from echodataflow.aspects.echodataflow_aspect import echodataflow
 from echodataflow.models.datastore import Dataset
-from echodataflow.models.output_model import EchodataflowObject, ErrorObject, Group, Output
+from echodataflow.models.output_model import EchodataflowObject, ErrorObject, Group
 from echodataflow.models.pipeline import Stage
 from echodataflow.utils import log_util
-from echodataflow.utils.file_utils import get_ed_list, get_out_zarr, get_working_dir, get_zarr_list, isFile
+from echodataflow.utils.file_utils import get_out_zarr, get_working_dir, get_zarr_list, isFile
 from src.model.BinaryHakeModel import BinaryHakeModel
 
 
@@ -216,7 +215,7 @@ def process_mask_prediction(
                 eflogging=config.logging,
             )
 
-            dims = ['ping_time', 'depth']
+            dims = stage.external_params.get('dims', ['ping_time', 'depth'])
             
             da_score_hake = assemble_da(score_tensor.numpy()[1,:,:], ds_ref=ed_list[0], dims=dims)
             

--- a/echodataflow/stages/subflows/open_raw.py
+++ b/echodataflow/stages/subflows/open_raw.py
@@ -31,6 +31,7 @@ from echodataflow.models.pipeline import Stage
 from echodataflow.utils import log_util
 from echodataflow.utils.file_utils import (
     download_temp_file,
+    extract_fs,
     get_out_zarr,
     get_working_dir,
     isFile,
@@ -216,7 +217,8 @@ def process_raw(
                     use_dask=stage.options["use_dask"],
                     eflogging=config.logging,
                 )
-                local_file.unlink()
+                fs = extract_fs(local_file, storage_options=config.output.storage_options_dict)
+                fs.rm(local_file, recursive=True)
         else:
             log_util.log(
                 msg={

--- a/echodataflow/stages/subflows/open_raw.py
+++ b/echodataflow/stages/subflows/open_raw.py
@@ -238,9 +238,10 @@ def process_raw(
         raw.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         raw.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:

--- a/echodataflow/stages/subflows/open_raw.py
+++ b/echodataflow/stages/subflows/open_raw.py
@@ -182,10 +182,14 @@ def process_raw(
                 use_dask=stage.options["use_dask"],
                 eflogging=config.logging,
             )
+            
+            external_kwargs = stage.external_params
+            
             ed = open_raw(
                 raw_file=local_file,
                 sonar_model=group.instrument,
                 storage_options=config.output.storage_options_dict,
+                **external_kwargs
             )
 
             log_util.log(
@@ -231,7 +235,13 @@ def process_raw(
         )
         raw.out_path = out_zarr
         raw.error = ErrorObject(errorFlag=False)
+        raw.stages[stage.name] = out_zarr
     except Exception as e:
+        log_util.log(
+            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
         raw.error = ErrorObject(errorFlag=True, error_desc=str(e))
     finally:
         return raw

--- a/echodataflow/stages/subflows/slice_store.py
+++ b/echodataflow/stages/subflows/slice_store.py
@@ -15,6 +15,7 @@ Author: Soham Butala
 Email: sbutala@uw.edu
 Date: August 22, 2023
 """
+
 from typing import Dict, Optional
 
 from prefect import flow
@@ -117,9 +118,10 @@ def slice_store(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_st
                 edf.stages[stage.name] = out_zarr
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": file_name},
+            msg={"msg": "", "mod_name": __file__, "func_name": file_name},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         edf.error = ErrorObject(errorFlag=True, error_desc=str(e))  
     return groups

--- a/echodataflow/stages/subflows/slice_store.py
+++ b/echodataflow/stages/subflows/slice_store.py
@@ -32,11 +32,9 @@ from echodataflow.utils import log_util
 from echodataflow.utils.file_utils import get_out_zarr, get_working_dir
 
 
-@flow(task_runner=SequentialTaskRunner())
+@flow
 @echodataflow(processing_stage="slice-store", type="FLOW")
 def slice_store(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_stage: Optional[Stage]):  
-    # TODO
-    # Add more logging    
     
     log_util.log(
             msg={
@@ -73,28 +71,74 @@ def slice_store(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_st
                 else:
                     identifier = "store"
                     storepath = edf.stages.get("store")
+                    
+                log_util.log(
+                    msg={
+                        "msg": f"Working on {identifier}",
+                        "mod_name": __file__,
+                        "func_name": "write_output",
+                    },
+                    use_dask=stage.options["use_dask"],
+                    eflogging=config.logging,
+                )
+                
                 nextsub = None
                 store = xr.open_zarr(storepath, storage_options=config.output.storage_options_dict)                
                 
                 if edf.start_time and edf.end_time:
+                    log_util.log(
+                        msg={
+                            "msg": f"Start Time: {edf.start_time} End Time: {edf.end_time}",
+                            "mod_name": __file__,
+                            "func_name": "write_output",
+                        },
+                        use_dask=stage.options["use_dask"],
+                        eflogging=config.logging,
+                    )
                     nextsub = store.sel(ping_time=slice(pd.to_datetime(edf.start_time, unit="ns"), pd.to_datetime(edf.end_time, unit="ns")))
                 else:                 
                     # get last processed index
                     var: Variable = Variable.get(name="last_"+ identifier +"_index", default=Variable(name="last_"+ identifier +"_index", value=0))
-                    
+                    log_util.log(
+                        msg={
+                            "msg": f"Slicing from last known index {var.value}",
+                            "mod_name": __file__,
+                            "func_name": "write_output",
+                        },
+                        use_dask=stage.options["use_dask"],
+                        eflogging=config.logging,
+                    )
                     # slice the store from the last processed index
                     sub = store.isel(ping_time=slice(int(var.value), None))
                     
                     # resample sub and store the new last processed index
                     sam = sub['ping_time'].resample(ping_time=stage.options.get("ping_time_bin", "10s"))                
                     last_v = max([v.start for v in sam.groups.values()])
-                    
+                    log_util.log(
+                        msg={
+                            "msg": f"Slicing till {last_v}",
+                            "mod_name": __file__,
+                            "func_name": "write_output",
+                        },
+                        use_dask=stage.options["use_dask"],
+                        eflogging=config.logging,
+                    )
                     nextsub = sub.isel(ping_time=slice(0, last_v))
-       
+                    
                 time_diffs = pd.Series(nextsub['ping_time'].values).diff()
 
                 one_hour = pd.Timedelta(hours=stage.external_params.get('ping_diff_threshold', 1))
                 time_diff_exceeds_one_hour = time_diffs > one_hour
+                
+                log_util.log(
+                    msg={
+                        "msg": f"Writing to zarr at {out_zarr}",
+                        "mod_name": __file__,
+                        "func_name": "write_output",
+                    },
+                    use_dask=stage.options["use_dask"],
+                    eflogging=config.logging,
+                )
     
                 nextsub.compute().to_zarr(
                     store=out_zarr,
@@ -105,7 +149,15 @@ def slice_store(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_st
                 )
                 
                 if any(time_diff_exceeds_one_hour):
-                        # Fail softly, probably rename the zarr store?
+                        log_util.log(
+                            msg={
+                                "msg": f"Time difference between some pings exceeded the set threshold of {stage.external_params.get('ping_diff_threshold', 1)} hour(s)",
+                                "mod_name": __file__,
+                                "func_name": "write_output",
+                            },
+                            use_dask=stage.options["use_dask"],
+                            eflogging=config.logging,
+                        )
                         edf.error = ErrorObject(errorFlag=True, 
                                                 error_desc=f"Time difference between any two pings crossed the threshold of {stage.external_params.get('ping_diff_threshold', 1)} hour(s)", 
                                                 error_type="INTERNAL")        

--- a/echodataflow/stages/subflows/slice_store.py
+++ b/echodataflow/stages/subflows/slice_store.py
@@ -1,0 +1,104 @@
+
+"""
+Echodataflow Slice_store Task
+
+This module defines a Prefect Flow and associated tasks for the Echodataflow Slice_store stage.
+
+Classes:
+    None
+
+Functions:
+    echodataflow_slice_store(config: Dataset, stage: Stage, data: Union[str, List[Output]])
+    process_slice_store(config: Dataset, stage: Stage, out_data: Union[List[Dict], List[Output]], working_dir: str)
+
+Author: Soham Butala
+Email: sbutala@uw.edu
+Date: August 22, 2023
+"""
+from typing import Dict, Optional
+
+from prefect import flow
+from prefect.task_runners import SequentialTaskRunner
+from prefect.variables import Variable
+import xarray as xr
+
+from echodataflow.aspects.echodataflow_aspect import echodataflow
+from echodataflow.models.datastore import Dataset
+from echodataflow.models.output_model import ErrorObject, Group
+from echodataflow.models.pipeline import Stage
+from echodataflow.utils import log_util
+from echodataflow.utils.file_utils import get_out_zarr, get_working_dir
+
+
+@flow(task_runner=SequentialTaskRunner())
+@echodataflow(processing_stage="slice-store", type="FLOW")
+def slice_store(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_stage: Optional[Stage]):  
+    # TODO
+    # Add more logging
+    # Determine starting index for each slice beforehand to execute this parallely
+    
+    log_util.log(
+            msg={
+                "msg": f" ---- Entering ----",
+                "mod_name": __file__,
+                "func_name": "write_output",
+            },
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
+    working_dir = get_working_dir(stage=stage, config=config)
+    
+    try:
+        for _, group in groups.items():
+            for edf in group.data:
+                file_name = edf.filename + "_StoreSlice.zarr"
+                
+                out_zarr = get_out_zarr(
+                    group=stage.options.get("group", True),
+                    working_dir=working_dir,
+                    transect=str(group.group_name),
+                    file_name= file_name,
+                    storage_options=config.output.storage_options_dict,
+                )
+            
+                # out_path will have sv and 'store' will have path to store
+                identifier = None
+                if edf.stages.get("Sv_store"):
+                    identifier = "sv"
+                    storepath = edf.stages.get("Sv_store")
+                elif edf.stages.get("MVBS_store"):
+                    identifier = "mvbs"
+                    storepath = edf.stages.get("MVBS_store")
+                else:
+                    identifier = "store"
+                    storepath = edf.stages.get("store")
+                
+                store = xr.open_zarr(storepath, storage_options=config.output.storage_options_dict)                
+                
+                # get last processed index
+                var: Variable = Variable.get(name="last_"+ identifier +"_index", default=Variable(name="last_"+ identifier +"_index", value=0))
+                
+                # slice the store from the last processed index
+                sub = store.isel(ping_time=slice(int(var.value), None))
+                
+                # resample sub and store the new last processed index
+                sam = sub['ping_time'].resample(ping_time=stage.options.get("ping_time_bin", "10s"))                
+                last_v = max([v.start for v in sam.groups.values()])
+                
+                nextsub = sub.isel(ping_time=slice(0, last_v))
+       
+                nextsub.compute().to_zarr(
+                    store=out_zarr,
+                    mode="w",
+                    consolidated=True,
+                    storage_options=config.output.storage_options_dict,
+                    safe_chunks=False,                    
+                )
+                
+                edf.out_path = out_zarr
+                edf.error = ErrorObject(errorFlag=False)     
+                Variable.set(name="last_"+ identifier +"_index", value=str(last_v + int(var.value)), overwrite=True)           
+    except Exception as e:
+        print(e)
+        raise e
+    return groups

--- a/echodataflow/stages/subflows/write_output.py
+++ b/echodataflow/stages/subflows/write_output.py
@@ -16,12 +16,7 @@ import zarr.storage
 # Coerce time if required
 
 @flow(task_runner=SequentialTaskRunner())
-def write_output(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_stage: Optional[Stage]):      
-    try:
-        zarr.storage.default_compressor = Zlib(level=3)
-    except Exception as e:
-        print(e)
-        pass
+def write_output(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_stage: Optional[Stage]):
     log_util.log(
             msg={
                 "msg": f" ---- Entering ----",

--- a/echodataflow/stages/subflows/write_output.py
+++ b/echodataflow/stages/subflows/write_output.py
@@ -1,0 +1,94 @@
+from typing import Dict, Optional
+from prefect import flow
+import xarray as xr
+from prefect.task_runners import SequentialTaskRunner
+import zarr.sync
+from echodataflow.models.datastore import Dataset
+from echodataflow.models.output_model import Group
+from echodataflow.models.pipeline import Stage
+from echodataflow.utils import log_util
+from echodataflow.utils.file_utils import get_out_zarr, get_working_dir, get_zarr_list, isFile
+from numcodecs import Zlib
+import zarr.storage
+
+# TODO
+# Hardcode to use Sequential runner
+# Coerce time if required
+
+@flow(task_runner=SequentialTaskRunner())
+def write_output(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_stage: Optional[Stage]):      
+    try:
+        zarr.storage.default_compressor = Zlib(level=3)
+    except Exception as e:
+        print(e)
+        pass
+    log_util.log(
+            msg={
+                "msg": f" ---- Entering ----",
+                "mod_name": __file__,
+                "func_name": "write_output",
+            },
+            use_dask=stage.options["use_dask"],
+            eflogging=config.logging,
+        )
+    working_dir = get_working_dir(stage=stage, config=config)
+    
+    try:
+        for _, group in groups.items():
+            for edf in group.data:
+                if edf.out_path:
+
+                    if stage.options and stage.options.get('store_mode', False):
+                        filename = config.name + ".zarr"
+                        mode = "a"      
+                        append_dim='ping_time'
+                    else:
+                        filename = edf.filename + ".zarr"
+                        mode = "w"
+                        append_dim = None
+                        
+                    out_zarr = get_out_zarr(
+                        group=stage.options.get("group", True),
+                        working_dir=working_dir,
+                        transect=str(group.group_name),
+                        file_name= filename,
+                        storage_options=config.output.storage_options_dict,
+                    )
+                    if not isFile(out_zarr, config.output.storage_options_dict):
+                        append_dim = None
+                    
+                    log_util.log(
+                    msg={
+                        "msg": f" {mode} {append_dim} For File {edf.out_path}",
+                        "mod_name": __file__,
+                        "func_name": group.group_name,
+                    },
+                    use_dask=stage.options["use_dask"],
+                    eflogging=config.logging,
+                    )
+                                    
+                    ed_list: xr.Dataset = get_zarr_list.fn(
+                    transect_data=edf, storage_options=config.output.storage_options_dict
+                    )[0]
+                    
+                    ed_list.to_zarr(
+                        store=out_zarr,
+                        mode=mode,
+                        consolidated=True,
+                        storage_options=config.output.storage_options_dict,
+                        append_dim=append_dim,
+                        synchronizer=zarr.sync.ThreadSynchronizer(),
+                        safe_chunks=False
+                    )
+                    
+                    if prev_stage.name == "echodataflow_compute_Sv":
+                        edf.stages["Sv_store"] = out_zarr                    
+                    elif prev_stage.name == "echodataflow_compute_MVBS":
+                        edf.stages["MVBS_store"] = out_zarr   
+                    else:
+                        edf.stages["store"] = out_zarr   
+                    
+    except Exception as e:
+        print(e)
+        raise e
+    return groups

--- a/echodataflow/stages/subflows/write_output.py
+++ b/echodataflow/stages/subflows/write_output.py
@@ -56,6 +56,7 @@ def write_output(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_s
                     )
                     if not isFile(out_zarr, config.output.storage_options_dict):
                         append_dim = None
+                        mode = "w"
                     
                     log_util.log(
                     msg={
@@ -71,6 +72,13 @@ def write_output(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_s
                     transect_data=edf, storage_options=config.output.storage_options_dict
                     )[0]
                     
+                    encoding = {}
+                    if mode == "w":
+                        for k, _ in ed_list.data_vars.items():
+                            encoding[k] = {"compressor": Zlib(level=2)}
+                    else:
+                        encoding = None
+                                        
                     ed_list.to_zarr(
                         store=out_zarr,
                         mode=mode,
@@ -78,6 +86,7 @@ def write_output(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_s
                         storage_options=config.output.storage_options_dict,
                         append_dim=append_dim,
                         synchronizer=zarr.sync.ThreadSynchronizer(),
+                        encoding=encoding,
                         safe_chunks=False
                     )
                     

--- a/echodataflow/stages/subflows/write_output.py
+++ b/echodataflow/stages/subflows/write_output.py
@@ -99,9 +99,10 @@ def write_output(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_s
                     
     except Exception as e:
         log_util.log(
-            msg={"msg": f"Some Error Occurred {str(e)}", "mod_name": __file__, "func_name": "Write Output"},
+            msg={"msg": "", "mod_name": __file__, "func_name": filename},
             use_dask=stage.options["use_dask"],
             eflogging=config.logging,
+            error=e
         )
         edf.error = ErrorObject(errorFlag=True, error_desc=str(e))  
     return groups

--- a/echodataflow/stages/subflows/write_output.py
+++ b/echodataflow/stages/subflows/write_output.py
@@ -90,9 +90,9 @@ def write_output(groups: Dict[str, Group], config: Dataset, stage: Stage, prev_s
                         safe_chunks=False
                     )
                     
-                    if "echodataflow_compute_Sv" in edf.stages.keys():
+                    if "echodataflow_compute_Sv" in edf.stages.keys() and "Sv_store" not in edf.stages.keys():
                         edf.stages["Sv_store"] = out_zarr                    
-                    elif "echodataflow_compute_MVBS" in edf.stages.keys():
+                    elif "echodataflow_compute_MVBS" in edf.stages.keys() and "MVBS_store" not in edf.stages.keys():
                         edf.stages["MVBS_store"] = out_zarr   
                     else:
                         edf.stages["store"] = out_zarr   

--- a/echodataflow/tests/flow_tests/MVBS_pipeline.yaml
+++ b/echodataflow/tests/flow_tests/MVBS_pipeline.yaml
@@ -24,7 +24,7 @@ pipeline:
     options:
       use_offline: true
     external_params:
-      range_meter_bin: 20m 
+      range_bin: 20m 
       ping_time_bin: 20S
       
   # - name: echodataflow_frequency_differencing

--- a/echodataflow/utils/file_utils.py
+++ b/echodataflow/utils/file_utils.py
@@ -392,7 +392,7 @@ def process_output_groups(
                 error_flag = True
                 
                 if error_type:
-                    if error_type != "INTERNAL":
+                    if error_type == "INTERNAL":
                         error_type = ed.error.error_type
                         error = ed.error.error_desc
                 else:

--- a/echodataflow/utils/file_utils.py
+++ b/echodataflow/utils/file_utils.py
@@ -300,7 +300,7 @@ def get_ed_list(
 def get_zarr_list(
     transect_data: Union[EchodataflowObject, List[EchodataflowObject]],
     storage_options: Dict[str, Any] = {},
-):
+) -> List[xr.Dataset]:
     """
     Get a list of xarray.Dataset objects for zarr data.
 
@@ -658,10 +658,10 @@ def get_out_zarr(
         if group:
             return os.path.join(working_dir, transect, file_name)
         else:
-            return os.path.join(working_dir, file_name)
+            return os.path.join(working_dir, "zarr_files", file_name)
     else:
         slash_pattern = "/" if "/" in working_dir else "\\"
         if group:
             return slash_pattern.join([working_dir, transect, file_name])
         else:
-            return slash_pattern.join([working_dir, file_name])
+            return slash_pattern.join([working_dir, "zarr_files", file_name])

--- a/echodataflow/utils/file_utils.py
+++ b/echodataflow/utils/file_utils.py
@@ -599,10 +599,10 @@ def cleanup(output:Output, config: Dataset, pipeline: Pipeline):
             for sname, path in edf.stages.items():
                 print(sname, path)
                 if not stages[sname]:
-        try:
+                    try:
                         fs = extract_fs(path, storage_options=config.output.storage_options_dict)
                         fs.rm(path, recursive=True)
-        except Exception as e:
+                    except Exception as e:
                         print("Failed to cleanup " + path)
 
 


### PR DESCRIPTION
## Major Upgrades to Echodataflow Pipeline

This PR introduces significant enhancements to the echodataflow pipeline, providing new capabilities and improving existing functionalities.

### Highlights:

#### New Flows Added

- `write_output`: Directs the current output to a specific location or store.
- `mask_prediction`: Utilizes an ML model to predict masks, which are then applied using the `apply_mask` function.
- `compute_NASC`: Calculates the Nautical Acoustic Scattering Coefficient (NASC) on the data.
- `resample`: Resamples and stores the output at a lower or higher resolution.
- `slice_store`: Slices the store based on time chunks, using Prefect variables to track the last sliced frame index. Currently supports only Zarr stores.

#### Issue Resolution:

- Codec Buffer Limit Error (resolves #103): Fixed the codec buffer limit error when writing masked output to a Zarr file. This ensures that `range_sample` is included in Zarr files.
- Switched from default `Blosc` encoding to `Zlib` which resolved [Intermittent Blosc Decompression Error During Zarr Operations](https://github.com/OSOceanAcoustics/echopype/issues/1338)

#### Support for New Input:

- **Store Mode**: Added support for new input via a store, enhancing flexibility. Store mode can be activated by specifying `storepath` in `datastore.yaml` instead of the traditional `urlpath`. 
  - `window_size`: Number of samples to slice from a Zarr store (e.g., 500).
  - `time_travel_hours`: Number of hours to go back from the last timestamp in the Zarr store (e.g., 2 hours).
  - `time_travel_mins`: Number of minutes to go back from the last timestamp in the Zarr store (e.g., 30 minutes).
  - `rolling_size`: Number of samples to go back in a Zarr store to set a starting point for a new window (e.g., 100). For non-overlapping windows, set `rolling_size` equal to `window_size`.

#### External Parameters Support:
    
Added support for external parameters in all flows, enabling more customizable and dynamic workflow configurations. External parameters must match the underlying process function, and echodataflow handles them only if explicitly required for pipeline processing.

#### Revamped Logging:

Logging improvements include better tracking, debugging, and overall transparency. Dask logs now maintain order, log tracebacks before failures, and resolve log contamination across pipeline runs in a Dask cluster setup (resolves #102).

#### Improved Post-Execution Cleanup:

Enhanced cleanup logic to manage and clean up resources after execution, improving reliability and efficiency.

- `save_offline` flag in `pipeline.yaml` prioritizes whether to keep intermediate files, while the `retention` flag acts as a default if `save_offline` is absent.
- **Note**: This does not delete any by-products generated by the pipeline, such as a Zarr store.

#### Exception Handling:

Added support for internal and external exceptions, clearly distinguishing between soft and hard failures.

- **Soft Failures**: Ensure that the flow status at the end of execution is marked as completed, which is useful for triggering Prefect automations despite internal errors.
- **Hard Failures**: Halt processing only if there are no more files to process, enhancing error resilience.

Resolves #100 
